### PR TITLE
RNKit を 2020.3.1 にアップデートする

### DIFF
--- a/HelloAyame/ios/Podfile.lock
+++ b/HelloAyame/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-cxxreact (= 0.62.0)
     - React-jsi (= 0.62.0)
     - ReactCommon/callinvoker (= 0.62.0)
-  - ReactNativeWebRTCKit (2020.3.0):
+  - ReactNativeWebRTCKit (2020.3.1):
     - React
     - WebRTC (~> 79.5.0)
   - RNVectorIcons (6.6.0):
@@ -448,7 +448,7 @@ SPEC CHECKSUMS:
   React-RCTText: 91a0d0ae5434aa28fe0c89c03eb9d660ff53bd9b
   React-RCTVibration: 0630aeb11e22f87c180ca9c0c3a0a0aba780cc62
   ReactCommon: d22162ab8f1358c53dfcd0f9c4d82d38facdbc48
-  ReactNativeWebRTCKit: 248e9ecb86dc90dbadf054ab2b73ba554eb6756e
+  ReactNativeWebRTCKit: 765680debc67721b8055fe7479d259b091a5e73d
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: f6746a0af43dae19e67ec2c26f2e10f7c8617c86
   Yoga: 9db9ff2025ad21d1ac0a8b3c85d5ac4e7c29d525

--- a/HelloAyame/package.json
+++ b/HelloAyame/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.62.0",
     "react-native-paper": "^3.6.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "^2020.3.0"
+    "react-native-webrtc-kit": "^2020.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloAyame/yarn.lock
+++ b/HelloAyame/yarn.lock
@@ -5090,10 +5090,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@^2020.3.0:
-  version "2020.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.3.0.tgz#e46c6cb8353b2bcd931bf6129c6803efb8796acc"
-  integrity sha512-xFpQIYYmyskY5tYyGNDuSakj3nyl5CLkwcsvmuBv/FlFQ75z2pDrh3O2U63S7N7gzSvCD70zcvlpPqBzkaEBvQ==
+react-native-webrtc-kit@^2020.3.1:
+  version "2020.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.3.1.tgz#f35b28e70f12ffc0b643e7e487ce90c3f0adf93b"
+  integrity sha512-g6qGOEyOviHQAQvhOwMgdAebggTEP+r0Zpnpjihy4SsFfNHHNlSyHCWgeoUBaz5muFB1YZBLvrfwhuV4yrI0nw==
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"


### PR DESCRIPTION
react-native-webrtc-kit のバージョンを 2020.3.1 にアップデートしました。
iOS と Android で簡単に動作確認をしています。